### PR TITLE
Fix lookup in other backends for trocla_options/trocla::options with puppet4 server

### DIFF
--- a/lib/hiera/backend/trocla_backend.rb
+++ b/lib/hiera/backend/trocla_backend.rb
@@ -14,6 +14,7 @@ class Hiera
           require 'trocla'
         end
 
+        Config.load_backends
         @trocla_conf = Config[:trocla] && Config[:trocla][:config]
         @trocla = ::Trocla.new(@trocla_conf)
       end


### PR DESCRIPTION
Hi

We use trocla_backend with our fresh puppet4 server and we have to apply this fix to get trocla_options/trocla::options to work.
Without it, hiera do not search trocla options in our other backends.

If you think this is dumb or there is a better solution, let me know and will try to test it.

Best